### PR TITLE
layouts/404: Fix homepage link

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -12,7 +12,7 @@
     <section>
         <h2>Whoops.</h2>
         <p>
-            The page you were looking for doesn't exist. Would you like to <a href="{{ .Site.Home }}">go to the home page</a>?
+            The page you were looking for doesn't exist. Would you like to <a href="{{ .Site.BaseURL }}">go to the home page</a>?
         </p>
     </section>
 {{ partial "footer.html" . }}


### PR DESCRIPTION
The link to the homepage on the 404 error page is broken. A link to
'Page("Name of homepage")' instead of the base URL is created.

Closes: #20 