### PR TITLE
Remove fallback font copypasta error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed some copy/paste errors in CSS `font-family` definitions [#38](https://github.com/AngeloStavrow/indigo/issues/38)
+
 ## [1.0.5]
 ### Fixed
 - Cleaned up some errant whitespace thanks to [@dixonge](https://github.com/dixonge)!
@@ -42,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - The first public release of the indigo theme for Hugo, along with related project documentation (including this changelog).
 
+[1.0.5]: https://github.com/AngeloStavrow/indigo/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/AngeloStavrow/indigo/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/AngeloStavrow/indigo/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/AngeloStavrow/indigo/compare/v1.0.1...v1.0.2

--- a/layouts/partials/fonts.css
+++ b/layouts/partials/fonts.css
@@ -7,7 +7,7 @@
          url('{{ .Site.BaseURL }}fonts/FiraCode-Regular.ttf') format('truetype');
     font-weight: 400;
     font-style: normal;
-    font-display: optional;
+    font-display: fallback;
 }
 
 @font-face {
@@ -16,7 +16,7 @@
     src: url('{{ .Site.BaseURL }}fonts/charter_regular-webfont.eot?#iefix') format('embedded-opentype'),
          url('{{ .Site.BaseURL }}fonts/charter_regular-webfont.woff') format('woff'),
          url('{{ .Site.BaseURL }}fonts/charter_regular-webfont.ttf') format('truetype');
-    font-display: optional;
+    font-display: fallback;
 }
 
 @font-face {
@@ -26,7 +26,7 @@
          url('{{ .Site.BaseURL }}fonts/charter_bold-webfont.woff') format('woff'),
          url('{{ .Site.BaseURL }}fonts/charter_bold-webfont.ttf') format('truetype');
     font-weight: bold;
-    font-display: optional;
+    font-display: fallback;
 }
 
 @font-face {
@@ -36,7 +36,7 @@
          url('{{ .Site.BaseURL }}fonts/charter_italic-webfont.woff') format('woff'),
          url('{{ .Site.BaseURL }}fonts/charter_italic-webfont.ttf') format('truetype');
     font-style: italic;
-    font-display: optional;
+    font-display: fallback;
 }
 
 @font-face {
@@ -47,7 +47,7 @@
          url('{{ .Site.BaseURL }}fonts/charter_bold_italic-webfont.ttf') format('truetype');
     font-style: italic;
     font-weight: bold;
-    font-display: optional;
+    font-display: fallback;
 }
 
 @font-face {
@@ -57,7 +57,7 @@
          url('{{ .Site.BaseURL }}fonts/FiraSans-Book.woff2') format('woff2'),
          url('{{ .Site.BaseURL }}fonts/FiraSans-Book.woff') format('woff'),
          url('{{ .Site.BaseURL }}fonts/FiraSans-Book.ttf') format('truetype');
-    font-display: optional;
+    font-display: fallback;
 }
 
 @font-face {
@@ -68,5 +68,5 @@
          url('{{ .Site.BaseURL }}fonts/FiraSans-Bold.woff') format('woff'),
          url('{{ .Site.BaseURL }}fonts/FiraSans-Bold.ttf') format('truetype');
     font-weight: bold;
-    font-display: optional;
+    font-display: fallback;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -96,7 +96,7 @@ body {
     background-color: #f8f8f8;
 }
 
-h1, h2, h3 {
+h1, h2, h3, h4, h5, h6 {
     font-family: "Fira Sans", Helvetica, Arial, sans-serif;
     font-weight: bold;
     margin-top: 2em;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -5,7 +5,7 @@
 body {
     background-color: #f8f8f8;
     color: #3f3f3f;
-    font-family: 'Charter', Fallback, serif;
+    font-family: 'Charter', Helvetica, Arial, serif;
     margin: 0 auto;
 }
 
@@ -97,7 +97,7 @@ body {
 }
 
 h1, h2, h3 {
-    font-family: 'Fira Sans', Fallback, sans-serif;
+    font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
     font-weight: bold;
     margin-top: 2em;
     padding-top: 0.15em;
@@ -147,7 +147,7 @@ section.content {
 p.post-date {
     background-color: #00416a;
     color: #dee5e9;
-    font-family: 'Fira Sans', Fallback, sans-serif;
+    font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
     font-size: smaller;
     margin: 0 0 2.5em 0;
     padding: 0.25em 0.5em;
@@ -164,7 +164,7 @@ h2.list-title {
 }
 
 p.list-post-date {
-    font-family: 'Fira Sans', Fallback, sans-serif;
+    font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
     font-size: smaller;
     margin: 1em 0 1.5em 0;
     padding: 0;
@@ -176,7 +176,7 @@ p.list-post-date {
 }
 
 .copyright {
-    font-family: 'Fira Sans', Fallback, sans-serif;
+    font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
     font-size: smaller;
     margin-top: 2em;
     text-align: center;
@@ -203,7 +203,7 @@ img.u-photo {
 }
 
 .card-subhead {
-    font-family: 'Fira Sans', Fallback, sans-serif;
+    font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
     font-size: smaller;
     text-transform: uppercase;
 }
@@ -221,7 +221,7 @@ blockquote {
 code {
     background-color: #dee5e9;
     color: #00416a;
-    font-family: 'Fira Code', Fallback, monospace;
+    font-family: 'Fira Code', Helvetica, Arial, monospace;
     padding: 0.1em 0.2em 0.1em 0.2em;
 }
 
@@ -252,7 +252,7 @@ a.permalink {
 }
 
 .post-tag {
-    font-family: 'Fira Sans', Fallback, sans-serif;
+    font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
     font-size: small;
     text-transform: uppercase;
 }
@@ -288,7 +288,7 @@ div#site-header > p {
 }
 
 div#page-nav, #pagination {
-    font-family: 'Fira Sans', Fallback, sans-serif;
+    font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
     font-size: smaller;
     line-height: 1em;
     margin: 1.5em 0 2.5em 0;
@@ -382,7 +382,7 @@ nav#article-skip {
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
-    font-family: 'Fira Sans', Fallback, sans-serif;
+    font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
     font-size: smaller;
     justify-content: space-around;
     line-height: 1em;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -221,7 +221,7 @@ blockquote {
 code {
     background-color: #dee5e9;
     color: #00416a;
-    font-family: "Fira Code", Helvetica, Arial, monospace;
+    font-family: "Fira Code", "Courier New", Courier, monospace;
     padding: 0.1em 0.2em 0.1em 0.2em;
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -5,7 +5,7 @@
 body {
     background-color: #f8f8f8;
     color: #3f3f3f;
-    font-family: 'Charter', Helvetica, Arial, serif;
+    font-family: "Charter", Helvetica, Arial, serif;
     margin: 0 auto;
 }
 
@@ -97,7 +97,7 @@ body {
 }
 
 h1, h2, h3 {
-    font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
+    font-family: "Fira Sans", Helvetica, Arial, sans-serif;
     font-weight: bold;
     margin-top: 2em;
     padding-top: 0.15em;
@@ -135,7 +135,7 @@ h2.list-title > a:hover {
 }
 
 a.read-more {
-    font-family: 'Fira Sans';
+    font-family: "Fira Sans";
     font-size: smaller;
     text-transform: uppercase;
 }
@@ -147,7 +147,7 @@ section.content {
 p.post-date {
     background-color: #00416a;
     color: #dee5e9;
-    font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
+    font-family: "Fira Sans", Helvetica, Arial, sans-serif;
     font-size: smaller;
     margin: 0 0 2.5em 0;
     padding: 0.25em 0.5em;
@@ -164,7 +164,7 @@ h2.list-title {
 }
 
 p.list-post-date {
-    font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
+    font-family: "Fira Sans", Helvetica, Arial, sans-serif;
     font-size: smaller;
     margin: 1em 0 1.5em 0;
     padding: 0;
@@ -176,7 +176,7 @@ p.list-post-date {
 }
 
 .copyright {
-    font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
+    font-family: "Fira Sans", Helvetica, Arial, sans-serif;
     font-size: smaller;
     margin-top: 2em;
     text-align: center;
@@ -203,7 +203,7 @@ img.u-photo {
 }
 
 .card-subhead {
-    font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
+    font-family: "Fira Sans", Helvetica, Arial, sans-serif;
     font-size: smaller;
     text-transform: uppercase;
 }
@@ -221,7 +221,7 @@ blockquote {
 code {
     background-color: #dee5e9;
     color: #00416a;
-    font-family: 'Fira Code', Helvetica, Arial, monospace;
+    font-family: "Fira Code", Helvetica, Arial, monospace;
     padding: 0.1em 0.2em 0.1em 0.2em;
 }
 
@@ -252,7 +252,7 @@ a.permalink {
 }
 
 .post-tag {
-    font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
+    font-family: "Fira Sans", Helvetica, Arial, sans-serif;
     font-size: small;
     text-transform: uppercase;
 }
@@ -288,7 +288,7 @@ div#site-header > p {
 }
 
 div#page-nav, #pagination {
-    font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
+    font-family: "Fira Sans", Helvetica, Arial, sans-serif;
     font-size: smaller;
     line-height: 1em;
     margin: 1.5em 0 2.5em 0;
@@ -382,7 +382,7 @@ nav#article-skip {
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
-    font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
+    font-family: "Fira Sans", Helvetica, Arial, sans-serif;
     font-size: smaller;
     justify-content: space-around;
     line-height: 1em;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -5,7 +5,7 @@
 body {
     background-color: #f8f8f8;
     color: #3f3f3f;
-    font-family: "Charter", Helvetica, Arial, serif;
+    font-family: "Charter", Times, "Times New Roman", serif;
     margin: 0 auto;
 }
 


### PR DESCRIPTION
**Related Issue**
This PR's content was first discussed in issue #38 

**Dependency Changes**
If relevant, list any dependencies added, removed, or changed.

**Testing**
- [x] Built and tested to work on a standalone Hugo site
- [x] Built and tested to work in the Hugo Theme Gallery demo site ([link](https://github.com/gohugoio/hugoThemes/blob/master/README.md))
- [x] Tested with browser's responsive-design tools

**Additional context**
Also taking this opportunity to change the value of the `font-display` CSS property in `/layout/partials/fonts.css` from `optional` to `fallback`. I've seen it happen where custom fonts aren't displayed on first load of the site, and this should fix that.
