### PR TITLE
Add mainSections parameter to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://github.com/AngeloStavrow/indigo.git
 
 There's a sample config.toml file in the root of the indigo theme directory (`config.toml.example`); copy it to the root of your Hugo site, and rename it to `config.toml` _after_ you've made a backup of your current config.toml file (if any).
 
-Set up the parameters in the config file, especially those in the social and `params.indieWeb` section. Social identifiers that you leave out will not be added to the footer of the site. If you prefer to use a content type other than `post`, be sure to change the `mainSections` parameter in the config file as well. For example, if you want content of type `posts` and `updates` to show up in lists, change the `mainSections` parameter to:
+Set up the parameters in the config file, especially those in the social and `params.indieWeb` section. Social identifiers that you leave out will not be added to the footer of the site. If you prefer to use a content type other than `post`, be sure to change the `mainSections` parameter in the config file as well. For example, if you want content of type `posts` and `updates` to show up in lists:
 
 ```toml
 [params]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ https://github.com/AngeloStavrow/indigo.git
 
 There's a sample config.toml file in the root of the indigo theme directory (`config.toml.example`); copy it to the root of your Hugo site, and rename it to `config.toml` _after_ you've made a backup of your current config.toml file (if any).
 
-Set up the parameters in the config file, especially those in the social and `params.indieWeb` section. Social identifiers that you leave out will not be added to the footer of the site.
+Set up the parameters in the config file, especially those in the social and `params.indieWeb` section. Social identifiers that you leave out will not be added to the footer of the site. If you prefer to use a content type other than `post`, be sure to change the `mainSections` parameter in the config file as well. For example, if you want content of type `posts` and `updates` to show up in lists, change the `mainSections` parameter to:
+
+```toml
+[params]
+  ...
+  mainSections = ["posts", "updates"]
+```
 
 You can configure the theme to show info about the author; by default, this information is shown; if you'd prefer to leave it out, set `ShowBio` to `false`.
 
@@ -40,13 +46,13 @@ Indigo will look for custom CSS in `<YOUR_HUGO_SITE>/static/css/custom.css`. Thi
 
 You can add a line to your `config.toml` file to set this theme as the default:
 
-```
+```toml
 theme = "indigo"
 ```
 
 Or, if you use `config.yaml`:
 
-```
+```yaml
 theme: indigo
 ```
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -12,6 +12,7 @@ theme = "indigo"
   Biography = "A short description, a few sentences describing the author. Set the 'ShowBio' parameter to false to hide this."
   ShowBio = true
   PermalinkText = "🔗"
+  mainSections = ["post"]
 
   # Contact/social-network identifiers for social icons
   EmailAddress = "email.address@example.com"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,7 +1,7 @@
 {{ partial "header.html" . }}
 <h2>{{ .Title }}</h2>
 <div id="content">
-{{ range $index, $page := (.Paginate (where .Site.RegularPages "Type" "post")).Pages }}
+{{ range $index, $page := (.Paginate (where .Site.RegularPages "Type" "in" site.Params.mainSections)).Pages }}
 {{ if ne $index 0 }}
 {{ end }}
 {{ .Render "li" }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 
 <!-- Content goes here -->
 <div id="content">
-{{ range $index, $page := (.Paginate (where (where .Site.RegularPages "Type" "post") ".Params.hidden" "!=" "true" )).Pages }}
+{{ range $index, $page := (.Paginate (where (where .Site.RegularPages "Type" "in" site.Params.mainSections) ".Params.hidden" "!=" "true" )).Pages }}
 {{ if ne $index 0 }}
 {{ end }}
 {{ .Render "li" }}


### PR DESCRIPTION
**Related Issue**
This PR's content was first discussed in and closes issue #56

**Dependency Changes**
This updates the config.toml file to include a `mainSections` parameter for specifying a preferred content type to be shown in list templates.

**Testing**
- [x] Built and tested to work on a standalone Hugo site
- [ ] Built and tested to work in the Hugo Theme Gallery demo site ([link](https://github.com/gohugoio/hugoThemes/blob/master/README.md))
- [x] Tested with browser's responsive-design tools

**Additional context**
N/A