### PR TITLE
Specify IndieWeb endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Added
+- Added entrypoints config section as described in [#73](https://github.com/AngeloStavrow/indigo/issues/73)
 
 ## [1.3.2] - 2019-10-17
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -40,3 +40,15 @@ theme = "indigo"
     MicroBlogUser = "MicroBlogUserName"
     Country = "CountryName"
     City = "CityName"
+
+  [params.endpoints]
+    Auth = "https://indieauth.com/auth"
+    Token = "https://tokens.indieauth.com/token"
+    # To get webmention support, just register at webmention.io and paste the link for endpoint here.
+    #Webmention = "https://webmention.io/<yourusername>/webmention"
+    # To get micropub support, you'll need to install a Micropub endpoint at your site and put its link there.
+    # To get an endpoint with Hugo support, use nanopub: https://github.com/dg01d/nanopub
+    # It will probably require some PHP hackery though, as it's fairly basic.
+    #Micropub = ""
+    # To get microsub support, you can use Aperture from p3k. Either go to https://aperture.p3k.io or self-host it (it's open source!)
+    #Microsub = ""

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,8 +17,15 @@
     {{ with .Site.Params.IndieWeb.GitHubUser }}<link rel="me" href="https://github.com/{{ . }}">{{ end }}
     {{ with .Site.Params.IndieWeb.TwitterUser }}<link rel="me" href="https://twitter.com/{{ . }}">{{ end }}
     {{ with .Site.Params.IndieWeb.MicroBlogUser }}<link rel="me" href="https://micro.blog/{{ . }}">{{ end }}
-    <!-- IndieAuth endpoint -->
-    <link rel="authorization_endpoint" href="https://indieauth.com/auth">
+    <!-- IndieWeb endpoints -->
+    <link rel="authorization_endpoint" href={{ .Site.Params.endpoints.Auth | default "https://indieauth.com/auth" }} />
+    <link rel="token_endpoint" href={{ .Site.Params.endpoints.Token | default "https://tokens.indieauth.com/token" }} />
+    {{ with .Site.Params.endpoints.Micropub }}
+    <link rel="micropub" href="{{ . }}" />{{ end }}
+    {{ with .Site.Params.endpoints.Microsub }}
+    <link rel="microsub" href="{{ . }}" />{{ end }}
+    {{ with .Site.Params.endpoints.Webmention}}
+    <link rel="webmention" href="{{ . }}" />{{ end }}
     <!-- Other stuff to make the site work -->
     <link rel="stylesheet" href={{ "css/fonts.css" | absURL }} />
     <link rel="stylesheet" href={{ "css/style.css" | absURL }} />


### PR DESCRIPTION
Adds support to specify IndieWeb endpoints #73 

I used the config that was specified on the Indigo Feature [writeup](https://web-work.tools/indieweb/indigo/features/)

It will default to the indieauth endpoints which is what it was doing.